### PR TITLE
WIP GQL-002 feat: add RTK

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-redux": "^8.0.5",
+    "redux-persist": "^6.0.0",
     "typescript": "5.0.4"
   },
   "devDependencies": {

--- a/src/hooks/reduxHooks.ts
+++ b/src/hooks/reduxHooks.ts
@@ -1,0 +1,6 @@
+import { AppDispatch, AppState } from '@store/store'
+import { useDispatch, useSelector } from 'react-redux'
+import type { TypedUseSelectorHook } from 'react-redux'
+
+export const useAppDispatch: () => AppDispatch = useDispatch
+export const useAppSelector: TypedUseSelectorHook<AppState> = useSelector

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,17 @@
+import { wrapper } from '@/store/store'
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
 
-export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+import { PersistGate } from 'redux-persist/integration/react'
+import { useStore } from 'react-redux'
+function App({ Component, pageProps }: AppProps) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const store: any = useStore()
+  return (
+    <PersistGate persistor={store.__persistor} loading={<div>Loading</div>}>
+      <Component {...pageProps} />
+    </PersistGate>
+  )
 }
+
+export default wrapper.withRedux(App)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,10 +2,15 @@ import Head from 'next/head'
 import Image from 'next/image'
 import { Inter } from 'next/font/google'
 import styles from '@/styles/Home.module.css'
+import { selectAuthState, setAuthState } from '@/store/slices/authSlice/authSlice'
+import { useDispatch, useSelector } from 'react-redux'
 
 const inter = Inter({ subsets: ['latin'] })
 
 export default function Home() {
+  const authState = useSelector(selectAuthState)
+  const dispatch = useDispatch()
+
   return (
     <>
       <Head>
@@ -20,6 +25,17 @@ export default function Home() {
             Get started by editing&nbsp;
             <code className={styles.code}>src/pages/index.tsx</code>
           </p>
+          <p>used this text for implementation https://blog.logrocket.com/use-redux-next-js/</p>
+          <div>
+            <div>{authState ? 'Logged in' : 'Not Logged In'}</div>
+            <button
+              onClick={() =>
+                authState ? dispatch(setAuthState(false)) : dispatch(setAuthState(true))
+              }
+            >
+              {authState ? 'Logout' : 'LogIn'}
+            </button>
+          </div>
           <div>
             <a
               href="https://vercel.com?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"

--- a/src/store/slices/authSlice/authSlice.ts
+++ b/src/store/slices/authSlice/authSlice.ts
@@ -1,0 +1,47 @@
+import { Action, createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { AppState } from '@store/store'
+import { HYDRATE } from 'next-redux-wrapper'
+
+interface HydrateAction<P> extends Action<typeof HYDRATE> {
+  payload: P
+}
+
+export type AppHydrateAction = HydrateAction<AppState>
+
+export interface AuthState {
+  authState: boolean
+}
+
+const initialState: AuthState = {
+  //TODO change to false after implementing authorization logic
+  authState: true,
+}
+
+export const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setAuthState: (state, action: PayloadAction<boolean>) => {
+      state.authState = action.payload
+    },
+  },
+
+  // Using the 'builder callback' notation instead of extraReducers object notation
+  extraReducers: (builder) => {
+    builder.addCase(HYDRATE, (state, action: HydrateAction<AppState>) => {
+      if (action.payload.auth) {
+        return {
+          ...state,
+          ...action.payload.auth,
+        }
+      }
+      return state
+    })
+  },
+})
+
+export const { setAuthState } = authSlice.actions
+
+export const selectAuthState = (state: AppState) => state.auth.authState
+
+export default authSlice.reducer

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,45 @@
+import { configureStore, ThunkAction, Action, combineReducers } from '@reduxjs/toolkit'
+import { authSlice } from './slices/authSlice/authSlice'
+import { createWrapper } from 'next-redux-wrapper'
+
+import { persistReducer, persistStore } from 'redux-persist'
+import storage from 'redux-persist/lib/storage'
+
+const rootReducer = combineReducers({
+  [authSlice.name]: authSlice.reducer,
+})
+
+const makeConfiguredStore = () =>
+  configureStore({
+    reducer: rootReducer,
+    devTools: true,
+  })
+
+export const makeStore = () => {
+  const isServer = typeof window === 'undefined'
+  if (isServer) {
+    return makeConfiguredStore()
+  } else {
+    // we need it only on client side
+    const persistConfig = {
+      key: 'nextjs',
+      whitelist: ['auth'], // make sure it does not clash with server keys
+      storage,
+    }
+    const persistedReducer = persistReducer(persistConfig, rootReducer)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const store: any = configureStore({
+      reducer: persistedReducer,
+      devTools: process.env.NODE_ENV !== 'production',
+    })
+    store.__persistor = persistStore(store) // Nasty hack
+    return store
+  }
+}
+
+export type AppStore = ReturnType<typeof makeStore>
+export type AppState = ReturnType<AppStore['getState']>
+export type AppDispatch = ReturnType<AppStore['dispatch']>
+export type AppThunk<ReturnType = void> = ThunkAction<ReturnType, AppState, unknown, Action>
+
+export const wrapper = createWrapper<AppStore>(makeStore)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,10 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@store/*": ["./src/store/*"],
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
[link used for solution](https://blog.logrocket.com/use-redux-next-js/)

:warning: :warning: :warning: ### Seems it's old solution
:warning: Was this warning
/!\ You are using legacy implementation. Please update your code: use createWrapper() and wrapper.useWrappedStore().
The object notation for `createSlice.extraReducers` is deprecated, and will be removed in RTK 2.0. Please use the 'builder callback' notation instead: https://redux-toolkit.js.org/api/createSlice
:white_check_mark: partly fixed